### PR TITLE
Adds the Advanced Plant Gene Editor Board to the techweb.

### DIFF
--- a/GainStation13/code/modules/research/designs/hydroponics.dm
+++ b/GainStation13/code/modules/research/designs/hydroponics.dm
@@ -1,0 +1,7 @@
+/datum/design/board/advplantgenes
+	name = "Machine Design (Advanced Plant Gene Editor Board)"
+	desc = "The circuit board for an advanced plant gene editor."
+	id = "adv_plantgenes"
+	build_path = /obj/item/circuitboard/machine/advplantgenes
+	category = list ("Misc. Machinery")
+	departmental_flags = DEPARTMENTAL_FLAG_SERVICE

--- a/GainStation13/code/modules/research/techweb/nutritech_nodes.dm
+++ b/GainStation13/code/modules/research/techweb/nutritech_nodes.dm
@@ -5,7 +5,8 @@
 	display_name = "Nutri-Tech Tools"
 	description = "Ending world hunger was never made easier!"
 	prereq_ids = list("biotech", "adv_engi")
-	design_ids = list("gainium_collar", "ci-nutrimentturbo", "bluespace_belt", "adipoelectric_transformer", "cookie_synthesizer", "borg_upgrade_cookiesynthesizer", "borg_upgrade_feedingtube", "ci-fatmobility","bluespace_collar_receiver","bluespace_collar_transmitter")
+	design_ids = list("gainium_collar", "ci-nutrimentturbo", "bluespace_belt", "adipoelectric_transformer", "cookie_synthesizer", "borg_upgrade_cookiesynthesizer",
+	"borg_upgrade_feedingtube", "ci-fatmobility","bluespace_collar_receiver","bluespace_collar_transmitter", "adv_plantgenes")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)
 	boost_item_paths = list(/obj/item/gun/energy/fatoray, /obj/item/gun/energy/fatoray/cannon, /obj/item/trash/fatoray_scrap1, /obj/item/trash/fatoray_scrap2)
 	hidden = TRUE


### PR DESCRIPTION
Under Nutri-Tech Tools.

## What & Why

The Advanced Plant Gene Editor allows botanists to modify the percentage value of any reagent disk, between a range of 1% - 20%. For example, a gene disk containing Nutriment Production 7% could be modified to suit any percentage within the range.

This allows botanists to create 'perfect' ratios for use in cooking, such as 2:1 flour to water to produce dough with no leftover reagents. This device is fairly cheap to create, but requires specific research in the tech tree, making it a simple addition to a late round botanist tool kit.

It is also meant to assist during a common situation where a chef is working the botany lab, or vice versa, allowing them to demonstrate their skills by producing more efficient plants, speeding up both jobs.

## Changelog
:cl:
add: Added the Advanced Plant Gene Editor board to the techweb.
:cl:
